### PR TITLE
Pod Sirius Rabbit increase high watermark

### DIFF
--- a/Pods/Sirius/Rabbit/deployment.yaml
+++ b/Pods/Sirius/Rabbit/deployment.yaml
@@ -57,10 +57,10 @@ spec:
           protocol: TCP
         resources:
           requests:
-            memory: "512Mi"
+            memory: "1024Mi"
             cpu: 0.1
           limits:
-            memory: "512Mi"
+            memory: "1024Mi"
             cpu: 1
         volumeMounts:
         - mountPath: /var/lib/rabbitmq/mnesia

--- a/Pods/Sirius/Rabbit/deployment.yaml
+++ b/Pods/Sirius/Rabbit/deployment.yaml
@@ -32,6 +32,8 @@ spec:
           value: /
         - name: RABBITMQ_DEFAULT_USER
           value: user.sirius
+        - name: RABBITMQ_VM_MEMORY_HIGH_WATERMARK
+          value: "0.8"
         - name: RABBITMQ_DEFAULT_PASS
           valueFrom:
             secretKeyRef:
@@ -55,7 +57,7 @@ spec:
           protocol: TCP
         resources:
           requests:
-            memory: "102Mi"
+            memory: "512Mi"
             cpu: 0.1
           limits:
             memory: "512Mi"


### PR DESCRIPTION
Increase high watermark - set to 80%, so with current limit it's 819MB